### PR TITLE
DOC improve flow with ngrok and cortex, add example delays

### DIFF
--- a/tutorials/movies_3T/00_setup_colab.py
+++ b/tutorials/movies_3T/00_setup_colab.py
@@ -8,7 +8,6 @@ when run from `Google Colab <https://colab.research.google.com/>`_). You can
 skip it if you run the tutorials on your machine.
 """
 # sphinx_gallery_thumbnail_path = "static/colab.png"
-#
 ###############################################################################
 # Change runtime to use a GPU
 # ---------------------------

--- a/tutorials/movies_3T/01_plot_explainable_variance.py
+++ b/tutorials/movies_3T/01_plot_explainable_variance.py
@@ -37,8 +37,6 @@ variance is also known as the *signal power*. For more information, see these
 references [1]_ [2]_ [3]_.
 """
 # sphinx_gallery_thumbnail_number = 1
-
-
 ###############################################################################
 # Path of the data directory
 # --------------------------
@@ -172,19 +170,11 @@ plt.show()
 #
 # The second mapper we provide maps the voxel data to a Freesurfer
 # average surface ("fsaverage"), that can be used in ``pycortex``.
-# First, let's download the "fsaverage" surface.
-
-import cortex
-
-surface = "fsaverage"
-
-if not hasattr(cortex.db, surface):
-    cortex.utils.download_subject(subject_id=surface)
-
-###############################################################################
+#
 # If you are running the notebook on Colab, you might need to update the
 # pycortex filestore as following:
 
+import cortex
 try:
     import google.colab  # noqa
     in_colab = True
@@ -202,10 +192,19 @@ if in_colab:
     cortex.quickflat.composite.db = cortex.database.db
 
 ###############################################################################
+# Now, let's download the "fsaverage" surface.
+
+surface = "fsaverage"
+
+if not hasattr(cortex.db, surface):
+    cortex.utils.download_subject(subject_id=surface)
+
+###############################################################################
 # Then, we load the "fsaverage" mapper. The mapper is a matrix of shape
 # (n_vertices, n_voxels), which maps each voxel to some vertices in the
 # fsaverage surface. It is stored as a sparse CSR matrix. The mapper is applied
 # with a dot product ``@`` (equivalent to ``np.dot``).
+
 from voxelwise_tutorials.io import load_hdf5_sparse_array
 voxel_to_fsaverage = load_hdf5_sparse_array(mapper_file,
                                             key='voxel_to_fsaverage')
@@ -220,14 +219,9 @@ print("(n_vertices,) =", ev_projected.shape)
 vertex = cortex.Vertex(ev_projected, surface, vmin=0, vmax=0.7, cmap='viridis')
 
 ###############################################################################
-# To start an interactive 3D viewer in the browser, use the ``webshow``
-# function.
-
-if False:
-    cortex.webshow(vertex, open_browser=False, port=8050)
-
-###############################################################################
-# If you are running the notebook on Colab, you need to tunnel the pycortex
+# To start an interactive 3D viewer in the browser, we can use the ``webshow``
+# function in pycortex.
+# If you are running the notebook on Colab, you first need to tunnel the pycortex
 # application out of Colab. To do so, use the following cell to start a tunnel
 # with ``ngrok`` and to get an address where the pycortex viewer will be made
 # accessible.
@@ -246,6 +240,17 @@ if in_colab:
           f"{result}\n"
           "and not the one proposed by pycortex ('Open viewer: ...')\n")
 
+
+###############################################################################
+# Now you can start an interactive 3D viewer by changing ``run_webshow`` to
+# ``True`` and running the following cell.  If you are using Colab, remember to
+# use the address returned by ngrok in the cell above rather than the address
+# returned by this cell.
+
+run_webshow = False
+if run_webshow:
+    cortex.webshow(vertex, open_browser=False, port=8050)
+
 ###############################################################################
 # Alternatively, to plot a flatmap in a ``matplotlib`` figure, use the
 # `quickshow` function.
@@ -254,7 +259,6 @@ if in_colab:
 # does not use this function, so feel free to ignore.)
 
 from cortex.testing_utils import has_installed
-
 
 fig = cortex.quickshow(vertex, colorbar_location='right',
                        with_rois=has_installed("inkscape"))

--- a/tutorials/movies_3T/03_plot_hemodynamic_response.py
+++ b/tutorials/movies_3T/03_plot_hemodynamic_response.py
@@ -182,14 +182,16 @@ x_delayed = delayer.fit_transform(x[:, None])
 # function.
 
 import matplotlib.pyplot as plt
-axs = plt.subplots(6, 1, figsize=(8, 6.5), constrained_layout=True, sharex=True)
+fig, axs = plt.subplots(6, 1, figsize=(8, 6.5), constrained_layout=True, 
+        sharex=True)
 times = np.arange(n_trs)*TR
 
 axs[0].plot(times, y, color="r")
 axs[0].set_title("BOLD response")
 for i, (ax, xx) in enumerate(zip(axs.flat[1:], x_delayed.T)):
   ax.plot(times, xx, color='k')
-  ax.set_title("$x(t - {0})$ (feature delayed by {0})".format(i))
+  ax.set_title("$x(t - {0:.0f})$ (feature delayed by {1} sample{2})".format(
+      i*TR, i, "" if i == 1 else "s"))
 for ax in axs.flat:
   ax.axvline(40, color='gray')
   ax.set_yticks([])

--- a/tutorials/movies_3T/04_plot_motion_energy_model.py
+++ b/tutorials/movies_3T/04_plot_motion_energy_model.py
@@ -147,7 +147,7 @@ print("(n_voxels,) =", scores_motion_energy.shape)
 ###############################################################################
 # Plot the model performances
 # ---------------------------
-# The performances are computed using the math:`R^2` scores.
+# The performances are computed using the :math:`R^2` scores.
 
 import matplotlib.pyplot as plt
 from voxelwise_tutorials.viz import plot_flatmap_from_mapper

--- a/tutorials/movies_3T/06_extract_motion_energy.py
+++ b/tutorials/movies_3T/06_extract_motion_energy.py
@@ -37,7 +37,7 @@ print(directory)
 # Load the stimuli images
 # -----------------------
 #
-# Here the data is not loaded in memory, we only take a peak at the data shape.
+# Here the data is not loaded in memory, we only take a peek at the data shape.
 
 import h5py
 


### PR DESCRIPTION
- Improve the flow for setting up a pycortex viewer in Colab. This order shouldn't require the user to go back and forth between cells if one of them fails.
- Add a couple of lines and a plot to give an intuitive understanding of what delaying features means